### PR TITLE
Add maven compile step in github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'oracle' 
-        java-version: '11'  
+        java-version: '17'  
     - name: Install linux rdma pre-required libs 
       run: |
           java --version && 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'oracle' 
-        java-version: '17'  
+        java-version: '11'  
     - name: Install linux rdma pre-required libs 
       run: |
           java --version && 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
          echo $(pwd) &&  cd ./libdisni && sudo sh ./build.sh     
     - name: Compile disni maven project 
       run: |
-         cd ../ && echo "$(pwd)" && mvn --version  && 
+         echo "$(pwd)" && mvn --version  && 
          ls * && 
          mvn -DskipTests install
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,5 +42,6 @@ jobs:
     - name: Compile disni maven project 
       run: |
          cd ../ && echo "$(pwd)" && mvn --version  && 
+         ls * && 
          mvn -DskipTests install
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Install JDK
       uses: actions/setup-java@v3
       with:
-        distribution: 'oracle' 
-        java-version: '17'  
+        distribution: 'temurin' 
+        java-version: '8'  
     - name: Install linux rdma pre-required libs 
       run: |
           java --version && 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,8 @@ jobs:
       run: |
           echo $(pwd) &&
           wget -nv -O /tmp/rdma-core.tar.gz https://github.com/linux-rdma/rdma-core/archive/refs/tags/v44.0.tar.gz   
-          cd /tmp && tar xzf rdma-core.tar.gz && 
+          cd /tmp && tar xzf rdma-core.tar.gz &&  
+          cd rdma-core-44.0/ && 
           sudo ./build.sh && 
           echo "rdma installed ok" 
     - name: Compile and build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Install JDK
       uses: actions/setup-java@v3
       with:
-        distribution: 'temurin' 
-        java-version: '8'  
+        distribution: 'oracle' 
+        java-version: '17'  
     - name: Install linux rdma pre-required libs 
       run: |
           java --version && 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,6 @@ jobs:
          echo $(pwd) &&  cd ./libdisni && sudo sh ./build.sh     
     - name: Compile disni maven project 
       run: |
-         echo "$(pwd)" && mvn --version  
+         cd ../ && echo "$(pwd)" && mvn --version  && 
+         mvn -DskipTests install
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Compile libdisni
+name: Compile disni
 
 on: [pull_request]
 
@@ -33,17 +33,11 @@ jobs:
           echo $(pwd) &&
           wget -nv -O /tmp/rdma-core.tar.gz https://github.com/linux-rdma/rdma-core/archive/refs/tags/v44.0.tar.gz   
           cd /tmp && tar xzf rdma-core.tar.gz && 
-          cd rdma-core-44.0/ && 
-          ls && 
           sudo ./build.sh && 
-          echo "find rdma_cma" && 
-          sudo find /tmp/rdma-core-44.0/ | grep 'rdma_cma' && 
-          echo "find rdma include" && 
-          sudo find /tmp/rdma-core-44.0/ | grep 'include' && 
-          echo "find rdma lib"  && 
-          sudo find /tmp/rdma-core-44.0/ | grep 'lib' && 
           echo "rdma installed ok" 
-    - name: cmake and build 
+    - name: Compile and build libdisni
       run: |
-         echo $(pwd) &&  cd ./libdisni && sudo sh ./build.sh      
-
+         echo $(pwd) &&  cd ./libdisni && sudo sh ./build.sh     
+    - name: Compile disni maven project 
+      run: |
+         echo "$(pwd)" && mvn --version  

--- a/pom.xml
+++ b/pom.xml
@@ -181,9 +181,26 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
         <configuration>
+          <verbose>true</verbose>
+          <fork>true</fork>
           <source>17</source>
           <target>17</target>
+          <compilerArgs>
+            <arg>--add-exports</arg>
+            <arg>java.base/sun.security.x509=ALL-UNNAMED</arg>
+            <arg>--add-exports</arg>
+            <arg>java.base/sun.security.util=ALL-UNNAMED</arg>
+            <arg>--add-exports</arg>
+            <arg>javax.annotation-api/javax.annotation=ALL-UNNAMED</arg>
+            <arg>--add-exports</arg>
+            <arg>java.base/sun.security.provider=ALL-UNNAMED</arg>
+            <arg>--add-exports</arg>
+            <arg>java.base/sun.security.pkcs=ALL-UNNAMED</arg>
+            <arg>--add-exports</arg>
+            <arg>java.naming/com.sun.jndi.ldap=ALL-UNNAMED</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -182,8 +182,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -185,8 +185,8 @@
         <configuration>
           <verbose>true</verbose>
           <fork>true</fork>
-          <source>17</source>
-          <target>17</target>
+          <source>11</source>
+          <target>11</target>
           <compilerArgs>
             <arg>--add-exports</arg>
             <arg>java.base/sun.security.x509=ALL-UNNAMED</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -185,21 +185,20 @@
         <configuration>
           <verbose>true</verbose>
           <fork>true</fork>
-          <source>11</source>
-          <target>11</target>
+          <source>17</source>
+          <target>17</target>
           <compilerArgs>
+            <!-- refer to https://issues.apache.org/jira/browse/SPARK-37719 -->
             <arg>--add-exports</arg>
-            <arg>java.base/sun.security.x509=ALL-UNNAMED</arg>
+            <arg>java.base/java.nio=ALL-UNNAMED</arg>
             <arg>--add-exports</arg>
-            <arg>java.base/sun.security.util=ALL-UNNAMED</arg>
+            <arg>java.base/sun.nio.ch=ALL-UNNAMED</arg>
             <arg>--add-exports</arg>
-            <arg>javax.annotation-api/javax.annotation=ALL-UNNAMED</arg>
+            <arg>java.base/java.nio=ALL-UNNAMED</arg>
             <arg>--add-exports</arg>
-            <arg>java.base/sun.security.provider=ALL-UNNAMED</arg>
+            <arg>java.base/java.lang=ALL-UNNAMED</arg>
             <arg>--add-exports</arg>
-            <arg>java.base/sun.security.pkcs=ALL-UNNAMED</arg>
-            <arg>--add-exports</arg>
-            <arg>java.naming/com.sun.jndi.ldap=ALL-UNNAMED</arg>
+            <arg>java.base/java.lang.invoke=ALL-UNNAMED</arg>
           </compilerArgs>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -182,8 +182,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>8</source>
+          <target>8</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
In this commit we add maven compile command in github workflow step.

github only supports oracle jdk >= 17 so we udpate corresponding maven plugin version and add extra commands by refering to spark jdk upgrade solution [link](https://issues.apache.org/jira/browse/SPARK-37719).